### PR TITLE
GitHub Actions: upgrade to Windows 2019

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   makepanda:
     strategy:
       matrix:
-        os: [ubuntu-16.04, windows-2016, macOS-10.14]
+        os: [ubuntu-16.04, windows-2019, macOS-10.14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
GitHub Actions is removing the `windows-2016` build environment on November 7, so upgrading to a newer Windows server is needed to continue running Windows builds on GitHub Actions.